### PR TITLE
Add changelog to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE README.md HISTORY.md requirements.txt Pipfile
+include LICENSE README.md HISTORY.md requirements.txt Pipfile CHANGELOG.md


### PR DESCRIPTION
The changelog was missing, causing building from source to fail as `setup.py` tried to read this file.