### PR TITLE
Modernize Python compatibilities and bump lspopt version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-latest]
+                os: [ubuntu-latest, windows-latest, macos-latest]
                 python-version: ["3.9", "3.10", "3.11", "3.12"]
         steps:
             -   uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,9 +15,9 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: ["3.9", "3.10", "3.11", "3.12"]
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
             -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v4
+                uses: actions/setup-python@v5
                 with:
                     python-version: ${{ matrix.python-version }}
             -   name: Upgrade pip. setuptools and wheel
@@ -37,7 +37,7 @@ jobs:
                 run: |
                     pytest tests --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=com --cov-report=xml --cov-report=html
             -   name: Upload pytest test results
-                uses: actions/upload-artifact@v3
+                uses: actions/upload-artifact@v4
                 with:
                     name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
                     path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+                python-version: [3.9, 3.10, 3.11, 3.12]
         steps:
             -   uses: actions/checkout@v3
             -   name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.9, 3.10, 3.11, 3.12]
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
         steps:
             -   uses: actions/checkout@v3
             -   name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ docs/_build/
 # PyBuilder
 target/
 
+# Environments
+.conda/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-01-07
+
+### Added
+
+- Support for Python 3.12
+- Support for `pip>=25`
+- Support for `numpy>=2`
+
+### Removed
+
+- Support for Python 3.7 and 3.8
+- Unused imports
+
+
 ## [1.3.0] - 2023-01-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Python 3.12
 - Support for `pip>=25`
 - Support for `numpy>=2`
+- Support for Windows and macOS
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To generate the taper windows only, use the `lspopt` method:
 
 ```python
 from lspopt import lspopt
-H, w = lspopt(N=256, c_parameter=20.0)
+H, w = lspopt(n=256, c_parameter=20.0)
 ```
     
 There is also a convenience method for using the [SciPy spectrogram method](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.spectrogram.html#scipy.signal.spectrogram)

--- a/generate_plot.py
+++ b/generate_plot.py
@@ -9,11 +9,6 @@ Created on 2015-12-02
 
 """
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import six
 import numpy as np
 from scipy.signal import chirp, spectrogram

--- a/lspopt/__version__.py
+++ b/lspopt/__version__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-version = "1.3.0"
+version = "1.4.0"
 __version__ = version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ DESCRIPTION = "A Python implementation of a multitaper window method for " \
 URL = 'https://github.com/hbldh/lspopt'
 EMAIL = 'henrik.blidh@gmail.com'
 AUTHOR = 'Henrik Blidh'
-REQUIRES_PYTHON = '>=3.7'
+REQUIRES_PYTHON = '>=3.9'
 VERSION = None
 
 REQUIRED = [
@@ -114,11 +114,10 @@ setup(
         'Operating System :: Unix',
         'Operating System :: MacOS',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,6 @@
 # Note: To use the 'upload' functionality of this file, you must:
 #   $ pip install twine
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-
 import io
 import os
 import sys

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -14,13 +14,6 @@ Created on 2015-11-14
 
 """
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
-import unittest
-
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,13 +14,6 @@ Created on 2015-11-14
 
 """
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
-import pytest
-import numpy as np
 from numpy.testing import assert_allclose
 
 from lspopt import utils


### PR DESCRIPTION
Just upgraded overall compatibilities and thought I would **bump the version** so that it would be easier to toss this onto PyPI. Changes listed below, copy/pasted from what I put in the `CHANGELOG.md` with some added links for context:


## [1.4.0] - 2025-01-07

### Added

- Support for Python 3.12  [ [Status of Python versions](https://devguide.python.org/versions/) ]
- Support for `pip>=25`  [ pypa/pip#11457 ]
- Support for `numpy>=2`
- Support for Windows and macOS

### Removed

- Support for Python 3.7 and 3.8
- Unused imports